### PR TITLE
Fixed styling error, preventing iframe border and window scrolling

### DIFF
--- a/stage.css
+++ b/stage.css
@@ -2,9 +2,11 @@ html, body {
   margin: 0;
   min-height: 100%;
   padding: 0;
+  overflow: hidden;
 }
 
 iframe {
   min-height: 100%;
   width: 100%;
+  border-style: none;
 }


### PR DESCRIPTION
When running twd on Ubuntu (GNOME, un-tested on others), the scrollbars cause the window to overflow and waste space.

The iframe also has a nasty border.

_Before_
![twd-before](https://cloud.githubusercontent.com/assets/7271686/4215335/77f23e16-38cd-11e4-8b9a-d9a26fea64fb.jpg)

_After_
![twd-after](https://cloud.githubusercontent.com/assets/7271686/4215338/7ed8dd66-38cd-11e4-805c-f0f23c893da9.jpg)
