### PR TITLE
Fixed width not readjusting on some devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     {
       "name": "André 'MKody' Fernandes",
       "email": "im@kdy.ch"
+    },
+    {
+      "name": "Resi Respati",
+      "email": "resir014@gmail.com"
     }
   ],
   "license": {

--- a/stage.css
+++ b/stage.css
@@ -1,5 +1,6 @@
 html, body {
   height: 100%;
+  width: 100%;
   margin: 0;
   overflow: hidden;
   position: fixed;


### PR DESCRIPTION
This pull request is based on the fixes found on #4.

I ran into this issue when trying to run twd on my Windows 10 laptop where the window launches without the `<body>` wrapper adjusting its width along with the window size.

![tweetdeck_2015-09-25_15-22-03](https://cloud.githubusercontent.com/assets/5663877/10096212/e4d1d738-6399-11e5-8c02-48f93dcd0100.png)

This small pull request should fix it.
